### PR TITLE
use `numpy.vectorize` if unable to sample function directly

### DIFF
--- a/pychebfun/chebfun.py
+++ b/pychebfun/chebfun.py
@@ -156,7 +156,10 @@ class Chebfun(Polyfun):
         Sample a function on N+1 Chebyshev points.
         """
         x = self.interpolation_points(N+1)
-        return f(x)
+        try:
+            return f(x)
+        except:  # needed when trying to sample functions which can't take a vector argument
+            return np.vectorize(f)(x)
 
     @classmethod
     def polyfit(self, sampled):
@@ -318,7 +321,7 @@ def chebfun(f=None, domain=[-1,1], N=None, chebcoeff=None,):
     """
     Create a Chebyshev polynomial approximation of the function $f$ on the interval :math:`[-1, 1]`.
 
-    :param callable f: Python, Numpy, or Sage function
+    :param callable f: any univariate real numerical function
     :param int N: (default = None)  specify number of interpolating points
     :param np.array chebcoeff: (default = np.array(0)) specify the coefficients
     """

--- a/tests/test_chebfun.py
+++ b/tests/test_chebfun.py
@@ -604,3 +604,20 @@ class TestRoots(unittest.TestCase):
 # 	def setUp(self):
 # 		Chebfun.record = True
 # 		self.p = Chebfun(segment,)
+
+def test_vectorize():
+    def not_vectorized(x):
+        if x > 0:
+            return 1
+        else:
+            return 0
+    Chebfun.sample_function(not_vectorized, 10)
+
+def test_sample_leaves_errors():
+    """
+    Chebfun.sample does not catch errors from the sampling function
+    """
+    def silly(x):
+        return 1/0
+    with pytest.raises(ZeroDivisionError):
+        Chebfun.sample_function(silly, 10)


### PR DESCRIPTION
**PyChebFun** is currently unable to fit to wrapped C functions. For instance, with the following simple C function compiled to a shared library and installed in the library path:

```C
#include <math.h>
double myfunc(double t) { return sin(2 * M_PI * t) + cos(2 * M_PI * t); }
```

**CTypes** is working fine:

```Python
from ctypes import *
libtest = CDLL("libtest.so")
myfunc = libtest.myfunc
myfunc.argtypes = [c_double]
myfunc.restype = c_double
myfunc(0.1)
Out[5]: 1.3968022466674206
```

but when trying to fit it using **PyChebFun**:

```Python
from pychebfun import *
cheb = chebfun(myfunc)
---------------------------------------------------------------------------
ArgumentError                             Traceback (most recent call last)
<ipython-input-9-a8e137328361> in <module>
----> 1 cheb = chebfun(myfunc)

/usr/local/lib/python3.6/dist-packages/pychebfun/chebfun.py in
chebfun(f, domain, N, chebcoeff)
    334     # callable
    335     if hasattr(f, '__call__'):
--> 336         return Chebfun.from_function(f, domain, N)
    337
    338     # from here on, assume that f is None, or iterable

/usr/local/lib/python3.6/dist-packages/pychebfun/polyfun.py in
from_function(self, f, domain, N)
    129
    130         # Find out the right number of coefficients to keep
--> 131         coeffs = self.dichotomy(**args)
    132
    133         return self.from_coeff(coeffs, domain)

/usr/local/lib/python3.6/dist-packages/pychebfun/polyfun.py in
dichotomy(self, f, kmin, kmax, raise_no_convergence)
     94             N = pow(2, k)
     95
---> 96             sampled = self.sample_function(f, N)
     97             coeffs = self.polyfit(sampled)
     98

/usr/local/lib/python3.6/dist-packages/pychebfun/chebfun.py in
sample_function(self, f, N)
    157         """
    158         x = self.interpolation_points(N+1)
--> 159         return f(x)
    160
    161     @classmethod

/usr/local/lib/python3.6/dist-packages/pychebfun/polyfun.py in <lambda>(t)
    119         a,b = domain[0], domain[-1]
    120         map_ui_ab = lambda t: 0.5*(b-a)*t + 0.5*(a+b)
--> 121         args = {'f': lambda t: f(map_ui_ab(t))}
    122         if N is not None: # N is provided
    123             nextpow2 = int(np.log2(N))+1

ArgumentError: argument 1: <class 'TypeError'>: wrong type
```

It is unclear to me why the trace is indicating `polyfun.py` line 121 as the site of the problem, which actually is at `chebfun.py` line 159.

Anyhow, the problem is that `f`, which is a **CTypes** wrapper object to the C function is getting passed a `numpy.array` object and it doesn't know what to do with it.

The solution is to use `numpy.vectorize` on the wrapper object to produce a new object that is able to handle `numpy.ndarray`.

However, I have patched it not to always use vectorize because I learnt [here](https://stackoverflow.com/a/35216364/) that it has some [issues](https://github.com/numpy/numpy/search?q=vectorize&type=Issues), so I'm using it only if the regular method fails.
